### PR TITLE
Allow using jest-prop-type-error with Create React App

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ If there is no jest section in your `package.json`, add one and use that.
 Now simply run your tests like usual, and prop-type errors will throw instead
 of logging a warning!
 
+# Usage with Create React App
+
+Create React App doesn't allow the use of the `setupFiles` directive. To use with 
+create-react-app, simply require 'jest-prop-type-error' in your `setupTests.js` file 
+after installing the package:
+
+      import 'jest-prop-type-error'
+
 # Requirements
 
 Requires node 6 or later


### PR DESCRIPTION
Hi - thanks so much for this package! Very useful.

Here's a PR to allow easy integration with Create React App. Let me know what you think or if you have any suggested changes?